### PR TITLE
Add missing metadata (repository, homepage, bugs)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,5 +15,13 @@
     "coffee-script": "~1.3.3",
     "mocha": "~1.2.2",
     "should": "~0.6.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/samcday/node-stream-splitter.git"
+  },
+  "homepage": "https://github.com/samcday/node-stream-splitter",
+  "bugs": {
+    "url": "https://github.com/samcday/node-stream-splitter/issues"
   }
 }


### PR DESCRIPTION
This should resolve

``` bash
npm WARN package.json stream-splitter@0.3.0 No repository field.
```

given by NPM.
